### PR TITLE
Make Shadow JAR the primary plugin artifact to include BSON runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,11 +103,12 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.named<ShadowJar>("shadowJar") {
-    dependsOn("jar")
-    archiveFileName.set("${project.name}.jar")
-    dependencies {
-        relocate("com.cryptomorin.xseries", "kernitus.plugin.OldCombatMechanics.lib.xseries")
-    }
+    archiveClassifier.set("")
+    relocate("com.cryptomorin.xseries", "kernitus.plugin.OldCombatMechanics.lib.xseries")
+}
+
+tasks.named<Jar>("jar") {
+    enabled = false
 }
 
 // For ingametesting
@@ -186,4 +187,3 @@ hangarPublish {
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- The plugin was loading a thin (unshaded) jar that lacked MongoDB BSON runtime classes (`org.bson.*`), causing `NoClassDefFoundError` at startup; the change ensures the shaded (fat) artifact is the primary output so runtime dependencies are bundled.

### Description
- Updated `build.gradle.kts` to remove the Shadow jar classifier (`archiveClassifier.set("")`) and disable the default `jar` task so the shadowed jar becomes the primary artifact, and kept the `XSeries` relocation (`kernitus.plugin.OldCombatMechanics.lib.xseries`).

### Testing
- Ran `./gradlew shadowJar` in the default environment and the build failed because the Gradle Kotlin DSL failed to parse the host Java version `25.0.1`, so packaging verification could not complete (failure).
- Ran `export JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2` and retried `./gradlew shadowJar`, which progressed past the Java version issue but failed to resolve the `com.gradleup.shadow` plugin from the Gradle plugin portal in this environment, so the shaded jar could not be produced locally (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba76c94bac832f92e31bb96cc3445f)