### PR TITLE
Colour old brewing stand title gold across versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,3 +257,4 @@ This file captures repo-specific context discovered while working on this branch
 - Green phase: only touch production code. Do not modify tests.
 - Refactor phase: cleanups only; keep behavior unchanged and tests green.
 - Validate phase: rerun tests and do a human sanity check before declaring done.
+- `ModuleOldBrewingStand` now sets the brewing stand custom name to a gold `Brewing Stand` title (`&6`/`§6`) during restock so the coloured title is visible across legacy and modern clients.

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldBrewingStand.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldBrewingStand.java
@@ -8,6 +8,7 @@ package kernitus.plugin.OldCombatMechanics.module;
 import kernitus.plugin.OldCombatMechanics.OCMMain;
 import kernitus.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -34,11 +35,14 @@ import java.util.Objects;
 public class ModuleOldBrewingStand extends OCMModule {
     private static final int MAX_FUEL = 20;
     private static final int FUEL_SLOT = 4;
+    private static final String BREWING_STAND_TITLE = ChatColor.GOLD + "Brewing Stand";
     private final Method setFuelLevelMethod;
+    private final Method setCustomNameMethod;
 
     public ModuleOldBrewingStand(OCMMain plugin) {
         super(plugin, "old-brewing-stand");
         setFuelLevelMethod = Reflector.getMethod(BrewingStand.class, "setFuelLevel", 1);
+        setCustomNameMethod = Reflector.getMethod(BrewingStand.class, "setCustomName", 1);
     }
 
     @EventHandler
@@ -139,8 +143,16 @@ public class ModuleOldBrewingStand extends OCMModule {
         }
 
         final BrewingStand brewingStand = (BrewingStand) blockState;
+        boolean updated = false;
+        if (setCustomNameMethod != null) {
+            Reflector.invokeMethod(setCustomNameMethod, brewingStand, BREWING_STAND_TITLE);
+            updated = true;
+        }
         if (setFuelLevelMethod != null) {
             Reflector.invokeMethod(setFuelLevelMethod, brewingStand, MAX_FUEL);
+            updated = true;
+        }
+        if (updated) {
             brewingStand.update();
         }
 


### PR DESCRIPTION
### Motivation
- Ensure brewing stands display a gold-coloured title (equivalent to `&6` / `§6`) to clients across the supported range (Minecraft 1.8 → 1.21.11). 

### Description
- Added a `BREWING_STAND_TITLE` constant using `ChatColor.GOLD` and resolved `setCustomName` on `BrewingStand` via the existing `Reflector` helper to preserve cross-version compatibility. 
- Apply the custom name during `restock(Block)` and only call `brewingStand.update()` when either the title or fuel was changed to avoid unnecessary updates. 
- Kept the original fuel-restock behaviour intact (set fuel level via reflected `setFuelLevel` and populate fuel slot). 
- Recorded the change in `AGENTS.md` per repository instructions. 

### Testing
- Attempted to compile with `./gradlew compileJava --no-daemon`, but the build failed because the environment lacks the required Java 17 toolchain, preventing full compilation and Kotlin-related tasks from running. 
- No integration or unit test artefacts were run in this environment due to the toolchain limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ba754b70832f9a0c2f311264400b)