### PR TITLE
Fix brewing-stand coloured title rendering across 1.8–1.21.11

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,4 @@ This file captures repo-specific context discovered while working on this branch
 - Refactor phase: cleanups only; keep behavior unchanged and tests green.
 - Validate phase: rerun tests and do a human sanity check before declaring done.
 - `ModuleOldBrewingStand` now sets the brewing stand custom name to a gold `Brewing Stand` title (`&6`/`§6`) during restock so the coloured title is visible across legacy and modern clients.
+- `ModuleOldBrewingStand` now sets the brewing-stand inventory view title via reflective `InventoryView#setTitle` (when available) using the same `§6Brewing Stand` formatting, so clients from 1.8 through 1.21.11 consistently see a coloured title while legacy versions still rely on the custom-name path.

--- a/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/OldBrewingStandIntegrationTest.kt
+++ b/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/OldBrewingStandIntegrationTest.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable
 
 @OptIn(ExperimentalKotest::class)
 class OldBrewingStandIntegrationTest : FunSpec({
+    val expectedBrewingTitle = "\u00A76Brewing Stand"
     val testPlugin = JavaPlugin.getPlugin(OCMTestMain::class.java)
     val module = ModuleLoader.getModules()
         .filterIsInstance<ModuleOldBrewingStand>()
@@ -62,6 +63,13 @@ class OldBrewingStandIntegrationTest : FunSpec({
 
     fun openBrewingView() = runSync {
         player.openInventory(brewingStand.inventory)
+    }
+
+    fun viewTitle(view: org.bukkit.inventory.InventoryView): String {
+        val titleMethod = view.javaClass.methods.firstOrNull {
+            it.name == "getTitle" && it.parameterCount == 0
+        } ?: error("InventoryView#getTitle not available for brewing stand test")
+        return titleMethod.invoke(view) as String
     }
 
     extensions(MainThreadDispatcherExtension(testPlugin))
@@ -133,6 +141,14 @@ class OldBrewingStandIntegrationTest : FunSpec({
             event.isCancelled.shouldBeTrue()
             topInventory.getItem(4)?.type shouldBe Material.BLAZE_POWDER
             fuelLevel(brewingStand.block.state as BrewingStand)?.let { it shouldBe 20 }
+        }
+    }
+
+    test("brewing stand title uses coloured formatting") {
+        val view = openBrewingView()
+
+        runSync {
+            viewTitle(view) shouldBe expectedBrewingTitle
         }
     }
 })

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldBrewingStand.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleOldBrewingStand.java
@@ -8,7 +8,6 @@ package kernitus.plugin.OldCombatMechanics.module;
 import kernitus.plugin.OldCombatMechanics.OCMMain;
 import kernitus.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -24,6 +23,7 @@ import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
 import java.lang.reflect.Method;
@@ -35,14 +35,16 @@ import java.util.Objects;
 public class ModuleOldBrewingStand extends OCMModule {
     private static final int MAX_FUEL = 20;
     private static final int FUEL_SLOT = 4;
-    private static final String BREWING_STAND_TITLE = ChatColor.GOLD + "Brewing Stand";
+    private static final String BREWING_STAND_TITLE = "\u00A76Brewing Stand";
     private final Method setFuelLevelMethod;
     private final Method setCustomNameMethod;
+    private final Method setInventoryViewTitleMethod;
 
     public ModuleOldBrewingStand(OCMMain plugin) {
         super(plugin, "old-brewing-stand");
         setFuelLevelMethod = Reflector.getMethod(BrewingStand.class, "setFuelLevel", 1);
         setCustomNameMethod = Reflector.getMethod(BrewingStand.class, "setCustomName", 1);
+        setInventoryViewTitleMethod = Reflector.getMethod(InventoryView.class, "setTitle", 1);
     }
 
     @EventHandler
@@ -50,6 +52,7 @@ public class ModuleOldBrewingStand extends OCMModule {
         if (!isEnabled(event.getPlayer())) {
             return;
         }
+        setBrewingViewTitle(event.getView());
         restock(event.getInventory());
     }
 
@@ -172,5 +175,13 @@ public class ModuleOldBrewingStand extends OCMModule {
 
     private static boolean isBlazePowder(ItemStack item) {
         return item != null && item.getType() == Material.BLAZE_POWDER;
+    }
+
+    private void setBrewingViewTitle(InventoryView view) {
+        if (setInventoryViewTitleMethod == null || view == null || !isBrewingInventory(view.getTopInventory())) {
+            return;
+        }
+
+        Reflector.invokeMethod(setInventoryViewTitleMethod, view, BREWING_STAND_TITLE);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the brewing-stand GUI title appears as a coloured, legacy-formatted string for clients from Minecraft 1.8 through 1.21.11, avoiding dependence on `ChatColor` APIs that can behave inconsistently across versions. 
- Provide a runtime-safe path to set the opened inventory title when newer `InventoryView#setTitle` APIs are present while preserving the existing custom-name restock behaviour for compatibility.

### Description
- Replaced `ChatColor.GOLD + "Brewing Stand"` with an explicit legacy-format constant `"\u00A76Brewing Stand"` in `ModuleOldBrewingStand` so the title uses the `§6` formatting code directly. 
- Added reflective lookup of `InventoryView#setTitle(String)` and a helper `setBrewingViewTitle(InventoryView)` that calls it when available and when the view is a brewing inventory, and invoked this helper on `InventoryOpenEvent`. 
- Kept the existing `setCustomName` restock path so legacy servers that rely on block custom name still work. 
- Extended `OldBrewingStandIntegrationTest` to assert the opened brewing view title equals `§6Brewing Stand` by adding an expected-title constant and a reflective `viewTitle(...)` helper that calls `getTitle` on the `InventoryView`. 
- Updated `AGENTS.md` to document the compatibility approach and the change to set the `InventoryView` title when available.

### Testing
- Attempted `./gradlew compileJava compileIntegrationTestKotlin` which failed because the `compileIntegrationTestKotlin` task is not defined in this project (task missing). 
- Attempted `./gradlew compileJava compileKotlin compileTestKotlin` and `./gradlew compileJava`, both of which failed due to the environment lacking the required Java 17 toolchain (toolchain auto-provisioning not configured). 
- No integration or unit tests were executed to completion in this environment due to the above toolchain/task limitations; the change includes an integration test addition that should run in CI or a local environment with the configured Java toolchains and integration test tasks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c14e1658832f98d2f3f59abd8648)